### PR TITLE
fix #5

### DIFF
--- a/half_orm_packager/templates/Pipfile
+++ b/half_orm_packager/templates/Pipfile
@@ -4,10 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-half_orm = "*"
+half-orm = "*"
 
 [dev-packages]
-hop = "*"
+half-orm-packager = "*"
 pytest = "*"
 build = "*"
 twine = "*"


### PR DESCRIPTION
Pour half_orm ça fonctionnait mais je trouvais plus propre comme ça, par contre pour setup.py je ne sais pas si cela fonctionne avec l'underscore.